### PR TITLE
Suppress a bunch of StyleCop rules

### DIFF
--- a/src/Formatting.Tests/Formatting.Tests.csproj
+++ b/src/Formatting.Tests/Formatting.Tests.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>Formatting.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>Formatting.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
@@ -70,6 +72,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Formatting.Tests.ruleset" />
     <None Include="app.config" />
     <None Include="project.json" />
   </ItemGroup>

--- a/src/Formatting.Tests/Formatting.Tests.ruleset
+++ b/src/Formatting.Tests/Formatting.Tests.ruleset
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Rules for LuaLanguageServicePackage" Description="Code analysis rules for LuaLanguageServicePackage.csproj." ToolsVersion="14.0">
+<RuleSet Name="Microsoft Managed Recommended Rules" Description="These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects." ToolsVersion="10.0">
+  <Localization ResourceAssembly="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.dll" ResourceBaseName="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.Localized">
+    <Name Resource="MinimumRecommendedRules_Name" />
+    <Description Resource="MinimumRecommendedRules_Description" />
+  </Localization>
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1001" Action="Warning" />
     <Rule Id="CA1009" Action="Warning" />
@@ -65,33 +69,26 @@
     <Rule Id="CA2242" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <Rule Id="SA1652" Action="None" />
     <Rule Id="SA1516" Action="Hidden" />
-    <Rule Id="SA1503" Action="Hidden" />
-    <Rule Id="SA1005" Action="Hidden" />
-    <Rule Id="SA1000" Action="Hidden" />
-    <Rule Id="SA1002" Action="Hidden" />
     <Rule Id="SA1028" Action="Hidden" />
-    <Rule Id="SA1025" Action="Hidden" />
     <Rule Id="SA1101" Action="Hidden" />
-    <Rule Id="SA1108" Action="Hidden" />
     <Rule Id="SA1116" Action="Hidden" />
-    <Rule Id="SA1110" Action="Hidden" />
-    <Rule Id="SA1117" Action="Hidden" />
-    <Rule Id="SA1119" Action="Hidden" />
-    <Rule Id="SA1129" Action="Hidden" />
-    <Rule Id="SA1130" Action="Hidden" />
-    <Rule Id="SA1133" Action="Hidden" />
-    <Rule Id="SA1202" Action="Hidden" />
-    <Rule Id="SA1203" Action="Hidden" />
-    <Rule Id="SA1204" Action="Hidden" />
-    <Rule Id="SA1513" Action="Hidden" />
+    <Rule Id="SA1633" Action="Hidden" />
+    <Rule Id="SA1500" Action="Hidden" />
     <Rule Id="SA1505" Action="Hidden" />
-    <Rule Id="SA1515" Action="Hidden" />
-    <Rule Id="SA1401" Action="Hidden" />
+    <Rule Id="SA1507" Action="Hidden" />
+    <Rule Id="SA1508" Action="Hidden" />
+    <Rule Id="SA1652" Action="Hidden" />
     <Rule Id="SA1400" Action="Hidden" />
-    <Rule Id="SA1311" Action="Hidden" />
-    <Rule Id="SA1308" Action="Hidden" />
-    <Rule Id="SA1127" Action="Hidden" />
+    <Rule Id="SA1513" Action="Hidden" />
+    <Rule Id="SA1306" Action="Hidden" />
+    <Rule Id="SA1515" Action="Hidden" />
+    <Rule Id="SA1202" Action="Hidden" />
+    <Rule Id="SA1201" Action="Hidden" />
+    <Rule Id="SA1122" Action="Hidden" />
+    <Rule Id="SA1117" Action="Hidden" />
+    <Rule Id="SA1005" Action="Hidden" />
+    <Rule Id="SA1200" Action="Hidden" />
+    <Rule Id="SA1210" Action="Hidden" />
   </Rules>
 </RuleSet>

--- a/src/LanguageModel.Tests/LanguageModel.Tests.csproj
+++ b/src/LanguageModel.Tests/LanguageModel.Tests.csproj
@@ -27,6 +27,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>LanguageModel.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -35,6 +36,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>LanguageModel.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -84,6 +86,7 @@
     <EmbeddedResource Include="CorrectSampleLuaFiles\assignment.lua">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
+    <None Include="LanguageModel.Tests.ruleset" />
     <None Include="App.config" />
     <None Include="CorrectSampleLuaFiles\AssignmentForIORead.lua">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/LanguageModel.Tests/LanguageModel.Tests.ruleset
+++ b/src/LanguageModel.Tests/LanguageModel.Tests.ruleset
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Rules for LuaLanguageServicePackage" Description="Code analysis rules for LuaLanguageServicePackage.csproj." ToolsVersion="14.0">
+<RuleSet Name="Microsoft Managed Recommended Rules" Description="These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects." ToolsVersion="10.0">
+  <Localization ResourceAssembly="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.dll" ResourceBaseName="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.Localized">
+    <Name Resource="MinimumRecommendedRules_Name" />
+    <Description Resource="MinimumRecommendedRules_Description" />
+  </Localization>
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1001" Action="Warning" />
     <Rule Id="CA1009" Action="Warning" />
@@ -65,33 +69,26 @@
     <Rule Id="CA2242" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <Rule Id="SA1652" Action="None" />
-    <Rule Id="SA1516" Action="Hidden" />
+    <Rule Id="SA1513" Action="Hidden" />
+    <Rule Id="SA1652" Action="Hidden" />
+    <Rule Id="SA1649" Action="Hidden" />
+    <Rule Id="SA1633" Action="Hidden" />
     <Rule Id="SA1503" Action="Hidden" />
     <Rule Id="SA1005" Action="Hidden" />
-    <Rule Id="SA1000" Action="Hidden" />
-    <Rule Id="SA1002" Action="Hidden" />
     <Rule Id="SA1028" Action="Hidden" />
-    <Rule Id="SA1025" Action="Hidden" />
     <Rule Id="SA1101" Action="Hidden" />
-    <Rule Id="SA1108" Action="Hidden" />
-    <Rule Id="SA1116" Action="Hidden" />
-    <Rule Id="SA1110" Action="Hidden" />
-    <Rule Id="SA1117" Action="Hidden" />
-    <Rule Id="SA1119" Action="Hidden" />
-    <Rule Id="SA1129" Action="Hidden" />
-    <Rule Id="SA1130" Action="Hidden" />
-    <Rule Id="SA1133" Action="Hidden" />
-    <Rule Id="SA1202" Action="Hidden" />
-    <Rule Id="SA1203" Action="Hidden" />
-    <Rule Id="SA1204" Action="Hidden" />
-    <Rule Id="SA1513" Action="Hidden" />
-    <Rule Id="SA1505" Action="Hidden" />
-    <Rule Id="SA1515" Action="Hidden" />
-    <Rule Id="SA1401" Action="Hidden" />
     <Rule Id="SA1400" Action="Hidden" />
-    <Rule Id="SA1311" Action="Hidden" />
-    <Rule Id="SA1308" Action="Hidden" />
-    <Rule Id="SA1127" Action="Hidden" />
+    <Rule Id="SA1508" Action="Hidden" />
+    <Rule Id="SA1517" Action="Hidden" />
+    <Rule Id="SA1507" Action="Hidden" />
+    <Rule Id="SA1300" Action="Hidden" />
+    <Rule Id="SA1202" Action="Hidden" />
+    <Rule Id="SA1201" Action="Hidden" />
+    <Rule Id="SA1515" Action="Hidden" />
+    <Rule Id="SA1516" Action="Hidden" />
+    <Rule Id="SA1122" Action="Hidden" />
+    <Rule Id="SA1116" Action="Hidden" />
+    <Rule Id="SA1200" Action="Hidden" />
+    <Rule Id="SA1208" Action="Hidden" />
   </Rules>
 </RuleSet>

--- a/src/LanguageModel/LanguageService.ruleset
+++ b/src/LanguageModel/LanguageService.ruleset
@@ -65,6 +65,39 @@
     <Rule Id="CA2242" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <Rule Id="SA1652" Action="None" />
+    <Rule Id="SA1005" Action="Hidden" />
+    <Rule Id="SA1013" Action="Hidden" />
+    <Rule Id="SA1025" Action="Hidden" />
+    <Rule Id="SA1028" Action="Hidden" />
+    <Rule Id="SA1101" Action="Hidden" />
+    <Rule Id="SA1108" Action="Hidden" />
+    <Rule Id="SA1116" Action="Hidden" />
+    <Rule Id="SA1117" Action="Hidden" />
+    <Rule Id="SA1119" Action="Hidden" />
+    <Rule Id="SA1122" Action="Hidden" />
+    <Rule Id="SA1128" Action="Hidden" />
+    <Rule Id="SA1131" Action="Hidden" />
+    <Rule Id="SA1133" Action="Hidden" />
+    <Rule Id="SA1202" Action="Hidden" />
+    <Rule Id="SA1203" Action="Hidden" />
+    <Rule Id="SA1204" Action="Hidden" />
+    <Rule Id="SA1206" Action="Hidden" />
+    <Rule Id="SA1208" Action="Hidden" />
+    <Rule Id="SA1300" Action="Hidden" />
+    <Rule Id="SA1311" Action="Hidden" />
+    <Rule Id="SA1312" Action="Hidden" />
+    <Rule Id="SA1400" Action="Hidden" />
+    <Rule Id="SA1402" Action="Hidden" />
+    <Rule Id="SA1500" Action="Hidden" />
+    <Rule Id="SA1502" Action="Hidden" />
+    <Rule Id="SA1503" Action="Hidden" />
+    <Rule Id="SA1505" Action="Hidden" />
+    <Rule Id="SA1507" Action="Hidden" />
+    <Rule Id="SA1508" Action="Hidden" />
+    <Rule Id="SA1509" Action="Hidden" />
+    <Rule Id="SA1513" Action="Hidden" />
+    <Rule Id="SA1516" Action="Hidden" />
+    <Rule Id="SA1518" Action="Hidden" />
+    <Rule Id="SA1652" Action="Hidden" />
   </Rules>
 </RuleSet>

--- a/src/LuaDebuggerLauncher/LuaDebuggerLauncher.csproj
+++ b/src/LuaDebuggerLauncher/LuaDebuggerLauncher.csproj
@@ -38,6 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <CodeAnalysisRuleSet>LuaDebuggerLauncher.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -47,6 +48,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <CodeAnalysisRuleSet>LuaDebuggerLauncher.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build" />
@@ -83,6 +85,7 @@
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
+    <None Include="LuaDebuggerLauncher.ruleset" />
     <None Include="[PlatformName]\ImportAfter\Lua.targets" />
     <None Include="[PlatformName]\ImportBefore\Lua.props" />
     <None Include="tools\CommonProjectSystemExtension.props" />

--- a/src/LuaDebuggerLauncher/LuaDebuggerLauncher.ruleset
+++ b/src/LuaDebuggerLauncher/LuaDebuggerLauncher.ruleset
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Rules for LuaLanguageServicePackage" Description="Code analysis rules for LuaLanguageServicePackage.csproj." ToolsVersion="14.0">
+<RuleSet Name="Microsoft Managed Recommended Rules" Description="These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects." ToolsVersion="10.0">
+  <Localization ResourceAssembly="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.dll" ResourceBaseName="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.Localized">
+    <Name Resource="MinimumRecommendedRules_Name" />
+    <Description Resource="MinimumRecommendedRules_Description" />
+  </Localization>
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1001" Action="Warning" />
     <Rule Id="CA1009" Action="Warning" />
@@ -65,33 +69,14 @@
     <Rule Id="CA2242" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <Rule Id="SA1652" Action="None" />
-    <Rule Id="SA1516" Action="Hidden" />
-    <Rule Id="SA1503" Action="Hidden" />
-    <Rule Id="SA1005" Action="Hidden" />
-    <Rule Id="SA1000" Action="Hidden" />
-    <Rule Id="SA1002" Action="Hidden" />
+    <Rule Id="SA1611" Action="Hidden" />
     <Rule Id="SA1028" Action="Hidden" />
-    <Rule Id="SA1025" Action="Hidden" />
-    <Rule Id="SA1101" Action="Hidden" />
-    <Rule Id="SA1108" Action="Hidden" />
-    <Rule Id="SA1116" Action="Hidden" />
-    <Rule Id="SA1110" Action="Hidden" />
-    <Rule Id="SA1117" Action="Hidden" />
-    <Rule Id="SA1119" Action="Hidden" />
-    <Rule Id="SA1129" Action="Hidden" />
-    <Rule Id="SA1130" Action="Hidden" />
-    <Rule Id="SA1133" Action="Hidden" />
-    <Rule Id="SA1202" Action="Hidden" />
-    <Rule Id="SA1203" Action="Hidden" />
-    <Rule Id="SA1204" Action="Hidden" />
+    <Rule Id="SA1002" Action="Hidden" />
+    <Rule Id="SA1121" Action="Hidden" />
     <Rule Id="SA1513" Action="Hidden" />
-    <Rule Id="SA1505" Action="Hidden" />
-    <Rule Id="SA1515" Action="Hidden" />
-    <Rule Id="SA1401" Action="Hidden" />
-    <Rule Id="SA1400" Action="Hidden" />
-    <Rule Id="SA1311" Action="Hidden" />
-    <Rule Id="SA1308" Action="Hidden" />
-    <Rule Id="SA1127" Action="Hidden" />
+    <Rule Id="SA1633" Action="Hidden" />
+    <Rule Id="SA1623" Action="Hidden" />
+    <Rule Id="SA1652" Action="Hidden" />
+    <Rule Id="SA1615" Action="Hidden" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
This is temporary. We should fix up the issues and re-enable them.
In the meantime, this really cleans up the build log.